### PR TITLE
Track how many characters are written for a log entry and optionally …

### DIFF
--- a/src/Redbox.Serilog.Stackdriver/CountingTextWriter.cs
+++ b/src/Redbox.Serilog.Stackdriver/CountingTextWriter.cs
@@ -1,0 +1,54 @@
+// Copyright 2019 Redbox Automated Retail LLC
+// Copyright 2018 Mehdi El Gueddari
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Origin source code for class from: 
+// https://github.com/mehdime/gcp-logging-playground
+
+using System.IO;
+using System.Text;
+
+namespace Redbox.Serilog.Stackdriver
+{
+    /// <summary>
+    /// Custom minimal text writer that will pass-through to a provided text writer but whilst doing so will
+    /// count the number of characters written.
+    /// </summary>
+    internal class CountingTextWriter : TextWriter
+    {
+        private readonly TextWriter originalOutput;
+
+        public CountingTextWriter(TextWriter originalOutput)
+        {
+            this.originalOutput = originalOutput;
+        }
+
+        public long CharacterCount { get; private set; } = 0;
+
+        //
+
+        public override Encoding Encoding => originalOutput.Encoding;
+
+        // NOTE: all other TextWriter overrides are written in terms of this, so we only have to
+        // .. subclass this to count characters
+        public override void Write(char value)
+        {
+            // increment count
+            CharacterCount++;
+
+            // defer actually write to the original writer
+            originalOutput.Write(value);
+        }
+    }
+}

--- a/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
+++ b/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
@@ -23,6 +23,8 @@ using Serilog.Events;
 using Serilog.Formatting.Compact;
 using Serilog.Formatting.Json;
 using Serilog.Formatting;
+using Serilog.Parsing;
+using System.Collections.Generic;
 
 namespace Redbox.Serilog.Stackdriver
 {
@@ -31,12 +33,19 @@ namespace Redbox.Serilog.Stackdriver
     /// but using property names that allow seemless integration with Stackdriver.
     /// </summary>
     public class StackdriverJsonFormatter : ITextFormatter
-    {        
+    {
+        // 256kb apparently, but we're conservative (https://cloud.google.com/logging/quotas)
+        public static int STACKDRIVER_ENTRY_LIMIT_BYTES = 200 * 1024; // 258kb, reduced to 200kb
+
+        //
+
+        private readonly bool _checkForPayloadLimit;
         readonly JsonValueFormatter _valueFormatter;
 
-        public StackdriverJsonFormatter(JsonValueFormatter valueFormatter = null)
+        public StackdriverJsonFormatter(bool checkForPayloadLimit = true, JsonValueFormatter valueFormatter = null)
         {
-            _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
+            this._checkForPayloadLimit = checkForPayloadLimit;
+            this._valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
         }
 
         /// <summary>
@@ -47,7 +56,6 @@ namespace Redbox.Serilog.Stackdriver
         public void Format(LogEvent logEvent, TextWriter output)
         {
             FormatEvent(logEvent, output, _valueFormatter);
-            output.WriteLine();
         }
 
         /// <summary>
@@ -56,11 +64,14 @@ namespace Redbox.Serilog.Stackdriver
         /// <param name="logEvent">The event to format.</param>
         /// <param name="output">The output.</param>
         /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
-        public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter)
+        public void FormatEvent(LogEvent logEvent, TextWriter originalOutput, JsonValueFormatter valueFormatter)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            if (output == null) throw new ArgumentNullException(nameof(output));
+            if (originalOutput == null) throw new ArgumentNullException(nameof(originalOutput));
             if (valueFormatter == null) throw new ArgumentNullException(nameof(valueFormatter));
+
+            // wrap the originally text writer in one that can count the number of characters written
+            var output = new CountingTextWriter(originalOutput);
 
             /*
              * 'timestamp', 'message', 'severity' and 'exception' are well-known
@@ -82,7 +93,7 @@ namespace Redbox.Serilog.Stackdriver
             var id = EventIdHash.Compute(logEvent.MessageTemplate.Text);
             output.Write(id.ToString("x8"));
             output.Write('"');
-            
+
             // SEVERITY
             // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
             output.Write(",\"severity\":\"");
@@ -111,6 +122,20 @@ namespace Redbox.Serilog.Stackdriver
             }
 
             output.Write('}');
+			output.WriteLine(); // finish the log line
+
+			// if we have blown the limit of a single stackdriver line (which means that error reporting won't parse 
+			// it correctly for instance) - then log that fact out too so we can adjust the logging and fix the problem
+			if (_checkForPayloadLimit && (output.CharacterCount * 4) >= STACKDRIVER_ENTRY_LIMIT_BYTES)
+			{
+				string text = "An attempt was made to write a log event to stackdriver that exceeds StackDriver Entry length limit - check logs for partially parsed entry just prior to this and fix at source";
+				var tooLongLogEvent = new LogEvent(
+					logEvent.Timestamp, LogEventLevel.Fatal, null,
+					new MessageTemplate(text, new MessageTemplateToken[] { new TextToken(text) }), // this is actually what gets rendered
+					new List<LogEventProperty>()
+				);
+				FormatEvent(tooLongLogEvent, output, valueFormatter);
+			}
         }
 
         /// <summary>
@@ -120,31 +145,13 @@ namespace Redbox.Serilog.Stackdriver
         /// <param name="formatter"></param>
         /// <param name="key"></param>
         /// <param name="value"></param>
-        public static void WriteKeyValue(TextWriter output, JsonValueFormatter formatter, 
+        public static void WriteKeyValue(TextWriter output, JsonValueFormatter formatter,
             string key, LogEventPropertyValue value, bool prependComma = true)
         {
-            if(prependComma) output.Write(',');
+            if (prependComma) output.Write(',');
             JsonValueFormatter.WriteQuotedJsonString(key, output);
             output.Write(':');
             formatter.Format(value, output);
-        }
-
-        /// <summary>
-        /// Outputs a key/value pair as json if the given input key is present in the LogEvent
-        /// </summary>
-        /// <param name="output"></param>
-        /// <param name="formatter"></param>
-        /// <param name="logEvent"></param>
-        /// <param name="outputKey"></param>
-        /// <param name="inputKey"></param>
-        public static void WriteIfPresent(TextWriter output, JsonValueFormatter formatter, LogEvent logEvent, 
-            string outputKey, string inputKey, bool prependComma = true)
-        {
-            if(logEvent.Properties.ContainsKey(inputKey) && logEvent.Properties[inputKey] != null)
-            {
-                var propertyValue = logEvent.Properties[inputKey];
-                WriteKeyValue(output, formatter, outputKey, propertyValue, prependComma: prependComma);
-            }
         }
     }
 }


### PR DESCRIPTION
…emit a (short) fatal error log entry if the Stackdriver entry limit is breached.

https://github.com/redboxllc/stackdriver-serilog/issues/6