### PR TITLE
Feature/message template

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Stackdriver will break the long line into multiple lines, which will break searc
 
 #### includeMessageTemplate
 
-Default `true`.  If the Serilog Message Template should be included in the logs, e.g. ` { ... "messageTemplate" : "Hello from {name:l}" ... }`
+Default `true`.  If the Serilog Message Template should be included in the logs, e.g. ` { ... "MessageTemplate" : "Hello from {name:l}" ... }`
 
 #### valueFormatter
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The class `StackdriverJsonFormatter` has two optional arguments:
 Default `true`.  Detects if a long line is longer than the [Stackdriver limit](https://cloud.google.com/logging/quotas) and if so adds an additional FATAL log warning of this.
 Stackdriver will break the long line into multiple lines, which will break search functionality of the json values.
 
+### includeMessageTemplate
+
+Default `true`.  If the Serilog Message Template should be included in the logs, e.g. ` { ... "messageTemplate" : "Hello from {name:l}" ... }`
+
 #### valueFormatter
 
 Defaults to `new JsonValueFormatter(typeTagName: "$type")`.  A valid Serilog JSON Formatter.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The class `StackdriverJsonFormatter` has two optional arguments:
 Default `true`.  Detects if a long line is longer than the [Stackdriver limit](https://cloud.google.com/logging/quotas) and if so adds an additional FATAL log warning of this.
 Stackdriver will break the long line into multiple lines, which will break search functionality of the json values.
 
-### includeMessageTemplate
+#### includeMessageTemplate
 
 Default `true`.  If the Serilog Message Template should be included in the logs, e.g. ` { ... "messageTemplate" : "Hello from {name:l}" ... }`
 

--- a/src/Redbox.Serilog.Stackdriver.Tests/StackdriverFormatterTests.cs
+++ b/src/Redbox.Serilog.Stackdriver.Tests/StackdriverFormatterTests.cs
@@ -12,17 +12,23 @@ namespace Redbox.Serilog.Stackdriver.Tests
     public class StackdriverFormatterTests
     {
         private static readonly DateTimeOffset DateTimeOffset = DateTimeOffset.Now;
-        private readonly LogEvent _logEventStandard = new LogEvent(DateTimeOffset, LogEventLevel.Debug, 
-            new Exception(), new MessageTemplate("{0}", new MessageTemplateToken[] { new TextToken("Hello") }), 
-            new LogEventProperty[0]);
-
+        
         [Fact]
         public void Test_StackdriverFormatter_Format()
         {
+            var propertyName = "greeting";
+            var propertyValue = "hello";
+            var logEvent = new LogEvent(DateTimeOffset, LogEventLevel.Debug, new Exception(), 
+                new MessageTemplate("{greeting}", 
+                    new MessageTemplateToken[] { new PropertyToken(propertyName, propertyValue, "l") }), 
+                new LogEventProperty[0]);
+            
             using var writer = new StringWriter();
-            new StackdriverJsonFormatter().Format(_logEventStandard, writer);
+            new StackdriverJsonFormatter().Format(logEvent, writer);
             var logDict = GetLogLineAsDictionary(writer.ToString());
+            
             AssertValidLogLine(logDict);
+            Assert.True(logDict["message"] == propertyValue);
         }
 
         [Fact]
@@ -70,7 +76,8 @@ namespace Redbox.Serilog.Stackdriver.Tests
         /// </summary>
         /// <param name="logDict"></param>
         /// <param name="hasException"></param>
-        private void AssertValidLogLine(Dictionary<string, string> logDict, bool hasException = true)
+        private void AssertValidLogLine(Dictionary<string, string> logDict, 
+            bool hasException = true)
         {
             Assert.True(logDict.ContainsKey("message"));
             Assert.NotEmpty(logDict["message"]);

--- a/src/Redbox.Serilog.Stackdriver.Tests/StackdriverFormatterTests.cs
+++ b/src/Redbox.Serilog.Stackdriver.Tests/StackdriverFormatterTests.cs
@@ -91,6 +91,9 @@ namespace Redbox.Serilog.Stackdriver.Tests
             
             Assert.True(logDict.ContainsKey("severity"));
             Assert.NotEmpty(logDict["severity"]);
+            
+            Assert.True(logDict.ContainsKey(("MessageTemplate")));
+            Assert.NotEmpty(logDict["MessageTemplate"]);
 
             if (hasException)
             {

--- a/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
+++ b/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
@@ -25,6 +25,7 @@ using Serilog.Formatting.Json;
 using Serilog.Formatting;
 using Serilog.Parsing;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Redbox.Serilog.Stackdriver
 {
@@ -38,12 +39,16 @@ namespace Redbox.Serilog.Stackdriver
         private static readonly int STACKDRIVER_ENTRY_LIMIT_BYTES = 200 * 1024; // 258kb, reduced to 200kb
 
         private readonly bool _checkForPayloadLimit;
-        readonly JsonValueFormatter _valueFormatter;
+        private readonly bool _includeMessageTemplate;
+        private readonly JsonValueFormatter _valueFormatter;
 
-        public StackdriverJsonFormatter(bool checkForPayloadLimit = true, JsonValueFormatter valueFormatter = null)
+        public StackdriverJsonFormatter(bool checkForPayloadLimit = true, 
+            bool includeMessageTemplate = true,
+            JsonValueFormatter valueFormatter = null)
         {
-            this._checkForPayloadLimit = checkForPayloadLimit;
-            this._valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
+            _checkForPayloadLimit = checkForPayloadLimit;
+            _includeMessageTemplate = includeMessageTemplate;
+            _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
         }
 
         /// <summary>
@@ -104,6 +109,13 @@ namespace Redbox.Serilog.Stackdriver
             {
                 output.Write(",\"exception\":");
                 JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+            }
+
+            // Serilog Message Template
+            if (_includeMessageTemplate)
+            {
+                output.Write(",\"messageTemplate\":");
+                JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
             }
 
             // Custom Properties passed in by code logging

--- a/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
+++ b/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
@@ -114,7 +114,8 @@ namespace Redbox.Serilog.Stackdriver
             // Serilog Message Template
             if (_includeMessageTemplate)
             {
-                output.Write(",\"messageTemplate\":");
+                // Capitalized to match default Serilog JsonFormatter
+                output.Write(",\"MessageTemplate\":");
                 JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
             }
 


### PR DESCRIPTION
* Adds Serilog message template to log output using `MessageTemplate`
Implements #5 

Example log:

```
{
//// New
    "MessageTemplate": "{HostingRequestFinishedLog:l}",
//// New
    "timestamp": "2020-06-15T20:57:59.4880630Z",
    "message": "Request finished in 3.4056ms 200 application/json; charset=utf-8",
    "fingerprint": "791a596a",
    "severity": "INFO",
    "ElapsedMilliseconds": 3.4056,
    "StatusCode": 200,
    "ContentType": "application/json; charset=utf-8",
    "HostingRequestFinishedLog": "Request finished in 3.4056ms 200 application/json; charset=utf-8",
    "EventId": {
        "Id": 2
    },
    "SourceContext": "Microsoft.AspNetCore.Hosting.Diagnostics",
    "RequestId": "0HM0HDR3BAS1B:00000001",
    "RequestPath": "/weatherforecast",
    "SpanId": "|4b0489f1-4565b2c5201fe8b3.",
    "TraceId": "4b0489f1-4565b2c5201fe8b3",
    "ParentId": "",
    "ConnectionId": "0HM0HDR3BAS1B",
    "Application": "Sample"
}
```