### PR TITLE
Optionally send Error-level logs to Cloud Error Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Default `true`.  If the Serilog Message Template should be included in the logs,
 Default `false`. If the `@type` property of the logs should be set to `type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent` when the log level is Error or above.
 This causes GCP to send these logs to Cloud Error Reporting. See [documentation](https://cloud.google.com/error-reporting/docs/grouping-errors).
 
+#### serviceName
+Defaults to the executing assembly name. Sets the service name used by GCP error reporting. 
+
+#### serviceVersion
+Defaults to the executing assembly version. Sets the service version used by GCP error reporting.
+
+#### markErrorsForErrorReporting
+Default `false`. If the `@type` property of the logs should be set to `type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent` when the log level is Error or above.
+This causes GCP to send these logs to Cloud Error Reporting. See [documentation](https://cloud.google.com/error-reporting/docs/grouping-errors).
+
 #### valueFormatter
 
 Defaults to `new JsonValueFormatter(typeTagName: "$type")`.  A valid Serilog JSON Formatter.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Be sure to add `.ReadFrom.Configuration(configuration)` to your Serilog setup fi
 
 ### Configuration Options
 
-The class `StackdriverJsonFormatter` has some optional arguments.
+The class `StackdriverJsonFormatter` has some optional arguments:
 
 #### checkForPayloadLimit
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Be sure to add `.ReadFrom.Configuration(configuration)` to your Serilog setup fi
 
 ### Configuration Options
 
-The class `StackdriverJsonFormatter` has two optional arguments:
+The class `StackdriverJsonFormatter` has some optional arguments.
 
 #### checkForPayloadLimit
 
@@ -61,6 +61,30 @@ Stackdriver will break the long line into multiple lines, which will break searc
 
 Default `true`.  If the Serilog Message Template should be included in the logs, e.g. ` { ... "MessageTemplate" : "Hello from {name:l}" ... }`
 
+#### markErrorsForErrorReporting
+Default `false`. If the `@type` property of the logs should be set to `type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent` when the log level is Error or above.
+This causes GCP to send these logs to Cloud Error Reporting. See [documentation](https://cloud.google.com/error-reporting/docs/grouping-errors).
+
 #### valueFormatter
 
 Defaults to `new JsonValueFormatter(typeTagName: "$type")`.  A valid Serilog JSON Formatter.
+
+Options can be passed in the `StackdriverJsonFormatter` constructor, or set in appsettings.json:
+```json
+"Serilog": {
+    "Using": [
+        "Serilog.Sinks.Console"
+    ],
+    "WriteTo": [
+    {
+        "Name": "Console",
+        "Args": {
+          "formatter": {
+            "type": "Redbox.Serilog.Stackdriver.StackdriverJsonFormatter, Redbox.Serilog.Stackdriver",
+            "markErrorsForErrorReporting": true,
+            "includeMessageTemplate": false
+          }        
+        }
+    }]
+}
+```

--- a/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
+++ b/src/Redbox.Serilog.Stackdriver/StackdriverJsonFormatter.cs
@@ -127,6 +127,14 @@ namespace Redbox.Serilog.Stackdriver
             {
                 output.Write(",\"@type\":");
                 output.Write("\"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\"");
+                
+                logEvent.Properties.TryGetValue("SourceContext", out var sourceContext);
+                if (sourceContext != null)
+                {
+                    output.Write(",\"context\":{\"reportLocation\":{");
+                    WriteKeyValue(output, valueFormatter, "filePath", sourceContext, false);
+                    output.Write("}}");
+                }
             }
 
             // Custom Properties passed in by code logging


### PR DESCRIPTION
GCP Cloud Error Reporting aggregates application errors by root cause. It automatically scans Cloud Logging messages for anything that looks like an exception with a stack trace, but sometimes we want it to recognize error logs as well. Google supports this by setting the `@type` property of the log to a specific value.

This PR adds a new parameter that, when enabled, will cause the formatter to set the `@type` to this value for any log with a level of Error or higher. These logs will then be processed by Cloud Error Reporting.

Error Reporting overview:
https://cloud.google.com/error-reporting/docs/grouping-errors

Log Formatting documentation:
https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text